### PR TITLE
Add horizontal scroll to tables

### DIFF
--- a/css/site-extra.css
+++ b/css/site-extra.css
@@ -442,6 +442,13 @@ tr:last-child {
   border-bottom-color: #c0c2c4;
 }
 
+doc table.tableblock {
+  word-wrap: normal;
+  word-break: keep-all;
+  display: block;
+  overflow-x: auto;
+}
+
 .doc table.tableblock thead th {
   border-bottom: 2.5px solid #c0c2c4;
   padding: .5rem;


### PR DESCRIPTION
For tables that have many columns where the current fixed/equal width column contents can become illegible.

Before:

![css-table-scroll-before](https://github.com/user-attachments/assets/3bb93a3c-3711-4ffe-b6c1-8c3d205b136a)

After:

![css-table-scroll-after](https://github.com/user-attachments/assets/5f72bf46-88df-4c93-84fa-5b798dec2950)
