### PR TITLE
Hide shared component

### DIFF
--- a/partials/nav-explore.hbs
+++ b/partials/nav-explore.hbs
@@ -1,0 +1,28 @@
+<div class="nav-panel-explore{{#unless page.navigation}} is-active{{/unless}}" data-panel="explore">
+  {{#if page.component}}
+  <div class="context">
+    <span class="title">{{page.component.title}}</span>
+    <span class="version">{{#if (or page.componentVersion.version (ne page.componentVersion.displayVersion 'default'))}}{{page.componentVersion.displayVersion}}{{/if}}</span>
+  </div>
+  {{/if}}
+  <ul class="components">
+    {{#each site.components}}
+      {{#unless (eq ./name 'shared')}}
+        <li class="component{{#if (eq this @root.page.component)}} is-current{{/if}}">
+          <div class="title"><a href="{{{relativize ./url}}}">{{{./title}}}</a></div>
+          {{#if (or ./versions.[1] ./versions.[0].version (ne ./versions.[0].displayVersion 'default'))}}
+          <ul class="versions">
+            {{#each ./versions}}
+            <li class="version
+              {{~#if (and (eq .. @root.page.component) (eq this @root.page.componentVersion))}} is-current{{/if~}}
+              {{~#if (eq this ../latest)}} is-latest{{/if}}">
+              <a href="{{{relativize ./url}}}">{{./displayVersion}}</a>
+            </li>
+            {{/each}}
+          </ul>
+          {{/if}}
+        </li>
+      {{/unless}}
+    {{/each}}
+  </ul>
+</div>


### PR DESCRIPTION
Some resources (e.g. partials, examples, images) are shared globally across versions+modules, but out-of-the-box Antora's expects a set of these resource folders per module like the below. To keep things DRY, a component (called "shared" in this case) is used to hold these shared resources. Example of implementation on the docs side at https://github.com/rancher/rancher-product-docs/pull/28.

This PR modifies `partials/nav-explore.hbs` (line 10 and 25) to only render components not named "shared" so that this component does not appear in the bottom-left component selector.

- component
  - modules
    - some_module1
      - partials
      - examples
      - images
      - pages
      - ...
    - some_module2
      - partials
      - examples
      - images
      - pages