### PR TITLE
Adjusted the submenu position relative to the parent menu

### DIFF
--- a/css/site-extra.css
+++ b/css/site-extra.css
@@ -111,7 +111,7 @@ i.fa[title='Tip:'] {
 .submenu {
   display: none;
   position: absolute;
-  left: -100%; 
+  left: -50%; 
   top: 0;
   background-color: white;
   border: 1px solid #ccc;


### PR DESCRIPTION
The PR fixes the issue where the submenu move far off from the parent menu for longer product names.

Before:

![image](https://github.com/user-attachments/assets/b9706955-674f-432e-b1b7-777aa0c95333)


After:

![image](https://github.com/user-attachments/assets/2dd77357-4d6a-49ad-b4b7-53c4f3837e11)
