### PR TITLE
Updated homepage link to documentation.suse.com

### DIFF
--- a/partials/header-content.hbs
+++ b/partials/header-content.hbs
@@ -2,7 +2,7 @@
   <nav class="navbar">
     <div class="navbar-brand">
       <div class="navbar-item">
-        <a class=" navbar-logo" href="https://documentation.suse.com/suma/"><img class="logo"
+        <a class=" navbar-logo" href="https://documentation.suse.com/"><img class="logo"
             src="{{uiRootPath}}/img/logo.svg" /></a>
       </div>
       {{#if env.SITE_SEARCH_PROVIDER}}


### PR DESCRIPTION
Setting the logo URL to https://documentation.suse.com/ for now. Once the products listing page is available then the  logo needs to be pointed to products listing page.