### PR TITLE
Extend active component background to boundary with version

### DIFF
--- a/css/site-extra.css
+++ b/css/site-extra.css
@@ -208,6 +208,14 @@ a.navbar-logo {
   color: #efefef;
 }
 
+.nav-panel-explore .context {
+  gap: 5px;
+}
+
+.nav-panel-explore .context .title {
+  flex: auto;
+}
+
 /* Left Nav Link styles  */
 .is-current-page>.nav-link, .is-current-page>.nav-text {
   font-weight: 700;
@@ -726,7 +734,7 @@ ul {
 .title {
   color: white;
   font-weight: 500;
-  padding: 0 15px;
+  padding-left: 15px;
   background-color: #0C322C;
   font-family: 'Poppins';
   padding-top: 10px;


### PR DESCRIPTION
#14 improved the active component background so that the padding is symmetrical, but there was still a visible gap between the title and version label. This PR extends the active component background to reach the boundary shared by the version label. This PR also reverts the adjustment to #14 as the title class is used by other elements. 

Before:
![active-component-background-before](https://github.com/user-attachments/assets/66bf661f-d2ba-4af3-aa4c-2b03832ac44f)

After with a short version label:
![active-component-background-after-long](https://github.com/user-attachments/assets/14d7885b-ef7b-4f0c-8d16-ca975a939ad1)

After with a longer version label:
![active-component-background-after-short](https://github.com/user-attachments/assets/5fed1f6a-8fd0-418b-a0c7-9f03fb335dcf)
