### PR TITLE
Remove background color from figcaption

### DIFF
--- a/css/site-extra.css
+++ b/css/site-extra.css
@@ -472,8 +472,21 @@ td, p {
   color:#0c322c;
 }
 
-.doc .admonitionblock .title, .doc .exampleblock .title, .doc .imageblock .title, .doc .listingblock .title, .doc .literalblock .title, .doc .openblock .title, .doc .tableblock caption {
+.doc .admonitionblock .title, .doc .exampleblock .title, .doc .listingblock .title, .doc .literalblock .title, .doc .openblock .title, .doc .tableblock caption {
   color: white;
+  font-size: .88889rem;
+  font-weight: 500;
+  font-style: normal;
+  -webkit-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+  letter-spacing: .01em;
+  padding-bottom: .075rem;
+  text-align: left;
+}
+
+.doc .imageblock .title {
+  background-color: transparent;
   font-size: .88889rem;
   font-weight: 500;
   font-style: normal;


### PR DESCRIPTION
With the background color in place, the caption stands out too much and looks disjointed from the rest of the document. This PR removes the background color and also removes the hardcoded white text color due to background color removal.

Current:

![figcaption-before](https://github.com/user-attachments/assets/75850454-2fa0-4af3-8fd8-8ebdee08e3e5)

After:

![figcaption-after](https://github.com/user-attachments/assets/e221b79a-3e3d-41b7-8b35-7c9c275c0171)
